### PR TITLE
support input ref for checks on branch/sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This action checks a repo for recent commits.
 
 **Required** The name of the repo. Defaults to `${{ github.repository }}` which evaluates to the repo from which this action is used.
 
+### `ref`
+
+**Required** SHA or branch to start listing commits from. Defaults to `${{ github.ref }}` which evaluates to the branch from which this action is used.
+
 ### `token`
 
 **Required** The github api token used to access the repo. Defaults to `${{ github.token }}` which evaluates to the token used by the current action. If this action is run against another private repo, use an appropriate token for access.

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'repo'
     required: true
     default: ${{ github.repository }}
+  ref:
+    description: 'branch or commit sha. defaults to current branch'
+    required: true
+    default: ${{ github.ref }}
   token:
     description: 'access token'
     required: true
@@ -27,6 +31,7 @@ runs:
     - id: check-commits
       env:
         INPUT_REPO: ${{ inputs.repo }}
+        INPUT_REF: ${{ inputs.ref }}
         INPUT_DAYS: ${{ inputs.days-since }}
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_PATH: ${{ inputs.path }}

--- a/check-commits-since.sh
+++ b/check-commits-since.sh
@@ -20,7 +20,7 @@ fi
 STATUS=$(curl -sLo "$OUTFILE" \
  --write-out "%{http_code}" \
  -H"Authorization: token $INPUT_TOKEN" \
- "$REPO_URL/commits?since=$SINCE_DATE&per_page=1$PATH_QUERY")
+ "$REPO_URL/commits?sha=$INPUT_REF&since=$SINCE_DATE&per_page=1$PATH_QUERY")
 
 if [ "$STATUS" -ne "$HTTP_OK" ]; then
   echo "checking commits for $INPUT_REPO. Expected $HTTP_OK. Got $STATUS"


### PR DESCRIPTION
add input `ref`
defaults to branch that triggered the originating action